### PR TITLE
Start dropbear by systemd unit if systemd is enabled.

### DIFF
--- a/dropbear.service
+++ b/dropbear.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Dropbear SSH Daemon
+DefaultDependencies=no
+Before=cryptsetup.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/dropbear -F -s -j -k
+
+[Install]
+WantedBy=cryptsetup.target

--- a/dropbear_install
+++ b/dropbear_install
@@ -92,7 +92,14 @@ build ()
   add_dir "/var/log"
   touch "${BUILDROOT}"/var/log/lastlog
 
-  add_runscript
+  #systemd enabled
+  declare -F add_systemd_unit > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+      add_file "/usr/share/mkinitcpio-dropbear/dropbear.service" "/etc/systemd/system/dropbear.service"
+      systemctl --root "$BUILDROOT" enable dropbear.service
+  else
+      add_runscript
+  fi
 }
 
 help ()


### PR DESCRIPTION
The hook scripts are not run in systemd mode, so a systemd unit is
required. This adds a custom unit that has the right ordering and
command line to start dropbear before the crypto setup step.

Signed-off-by: Toke Høiland-Jørgensen toke@toke.dk
