### PR TITLE
Fix "Login attempt with nonexistent user"

### DIFF
--- a/dropbear_install
+++ b/dropbear_install
@@ -86,6 +86,9 @@ build ()
   add_dir "/root/.ssh"
   cat /etc/dropbear/root_key > "${BUILDROOT}"/root/.ssh/authorized_keys
 
+  groupadd --prefix "${BUILDROOT}" --system -g 0 root
+  useradd --prefix "${BUILDROOT}" --system -g root -u 0 -M -d /root -s /bin/sh root
+
   add_full_dir "/etc/dropbear"
   add_file "/lib/libnss_files.so.2"
   add_dir "/var/run"


### PR DESCRIPTION
As there is no passwd / group file existent in the ramdisk,
loging in the root user isn't possible and it will fail
with the message from above.

This commit fixes the issue by adding the root user / group using
groupadd and useradd tools. I recommend to use these tools,
because they only will add an additional line if the user / group
doesn't exist already.