### PR TITLE
Add a suggestion to convert keyfiles to PEM format

### DIFF
--- a/dropbear_install
+++ b/dropbear_install
@@ -24,13 +24,21 @@ copy_openssh_keys() {
   local return_code=1
 
   if [ -s "$osshrsa" ]; then
-      dropbearconvert openssh dropbear $osshrsa ${dbpre}rsa_host_key
+    if dropbearconvert openssh dropbear $osshrsa ${dbpre}rsa_host_key; then
       return_code=0
+    else
+      echo "dropbearconvert needs host keys in PEM format"
+      echo "To convert existing host key use: \"ssh-keygen -p -m PEM -f $osshrsa\""
+    fi
   fi
 
   if [ -s "$osshecdsa" ]; then
-      dropbearconvert openssh dropbear $osshecdsa ${dbpre}ecdsa_host_key
+    if dropbearconvert openssh dropbear $osshecdsa ${dbpre}ecdsa_host_key; then
       return_code=0
+    else
+      echo "dropbearconvert needs host keys in PEM format"
+      echo "To convert existing host key use: \"ssh-keygen -p -m PEM -f $osshecdsa\""
+    fi
   fi
 
   return $return_code


### PR DESCRIPTION
This commit adds additional output to the following Error
message informing the user they need to convert their existing
ssh_host key files to PEM format.

```
Error: Unsupported OpenSSH key type
Error reading key from '/etc/ssh/ssh_host_rsa_key'
Error: Unsupported OpenSSH key type
Error reading key from '/etc/ssh/ssh_host_ecdsa_key'
```

I found the suggestion to convert the existing keys to PEM format in
an issue[1] for systemd-tool and I've converted the suggestion to an
echo statement during a failure to convert the keys when running
mkinitcpio when dropbear hook is enabled.

Also this change stops swallowing this error. The new behavior is,
if dropbear convert was unable to convert any existing `ssh_host`
key files then `generate_keys` will be run. This prevents an initramfs
being generated without any host keyfiles. This is the same behavior
that occurs when NO existing `ssh_host` keyfiles exist.

[1] random-archer/mkinitcpio-systemd-tool#83