### PR TITLE
Allow dropbear.conf to customize listen address

### DIFF
--- a/dropbear_hook
+++ b/dropbear_hook
@@ -6,7 +6,16 @@ run_hook ()
   mount -t devpts devpts /dev/pts
 
   echo "Starting dropbear"
-  /usr/sbin/dropbear -E -s -j -k
+
+  # Configuration processing and dropbear execution is done in a subshell
+  # to prevent dropbear.conf from inadvertently clobbering important variables
+  # or terminating the shell that is running /init.
+  (
+    # Load configuration options (currently only default listen address)
+    [ -r /etc/dropbear/dropbear.conf ] && . /etc/dropbear/dropbear.conf
+    /usr/sbin/dropbear -E -s -j -k -p "${dropbear_listen:-22}"
+  )
+
 }
 
 run_cleanuphook ()


### PR DESCRIPTION
Especially if the initramfs host keys differ from the primary system host keys, it may be desirable to have dropbear listen on a non-standard port to prevent clients complaining about changed keys. Let's add an optional file, `/etc/dropbear/dropbear.conf`, that will be copied into the initramfs and will be sourced by `run_hook` before invoking dropbear. Currently, the only recognized option that can be defined here is `dropbear_listen`, which defines the argument for the dropbear `-p` flag.